### PR TITLE
Add preserveLeadingWhitespaces and preserveTrailingWhitespaces variables under logsCollection.containers in values.yaml

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -423,6 +423,8 @@ receivers:
       {{- range $_, $excludePath := .Values.logsCollection.containers.excludePaths }}
       - {{ $excludePath }}
       {{- end }}
+    preserve_leading_whitespaces: {{ .Values.logsCollection.containers.preserveLeadingWhitespaces | default false }}
+    preserve_trailing_whitespaces: {{ .Values.logsCollection.containers.preserveTrailingWhitespaces | default false }}
     start_at: beginning
     include_file_path: true
     include_file_name: false

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -833,6 +833,12 @@
             },
             "maxRecombineLogSize": {
               "type": "integer"
+            },
+            "preserveLeadingWhitespaces":{
+              "type": "boolean"
+            },
+            "preserveTrailingWhitespaces": {
+              "type": "boolean"
             }
           }
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -621,6 +621,11 @@ logsCollection:
     # Set to 0 to remove any size limit.
     maxRecombineLogSize: 1048576
 
+    # Whether to preserve leading whitespaces in logs.
+    preserveLeadingWhitespaces: false
+    # Whether to preserve trailing whitespaces in logs.
+    preserveTrailingWhitespaces: false
+
 # Configuration for collecting journald logs using otel collector
   journald:
     enabled: false


### PR DESCRIPTION


**Description:** Added preserveLeadingWhitespaces and preserveTrailingWhitespaces  which allow users to change whether they want leading and trailing spaces removed from their logs while using filelog receiver.


**Testing:** Manual testing

